### PR TITLE
Update the configmap part in dc and fix the task in remove.yml

### DIFF
--- a/roles/indy/defaults/main.yml
+++ b/roles/indy/defaults/main.yml
@@ -7,7 +7,7 @@ deployment_config: yes
 image_from: Commonjava/indy:latest
 
 image_name: indy
-image_namespace: jdcasey-testing
+image_namespace: "{{ namespace }}"
 
 res:
   - cpu: 512Mi

--- a/roles/openshift-simple-service/tasks/remove.yml
+++ b/roles/openshift-simple-service/tasks/remove.yml
@@ -12,4 +12,4 @@
       metadata:
         name: "{{ item.name|default(app) }}"
         namespace: "{{ namespace }}"
-    with_items: "{{ items }}"
+  with_items: "{{ items }}"

--- a/roles/openshift-simple-service/templates/deployment-config.yml.j2
+++ b/roles/openshift-simple-service/templates/deployment-config.yml.j2
@@ -101,8 +101,8 @@ spec:
 {% if configmaps is defined %}
 {% for v in configmaps %}
       - name: vol-{{ v.name }}
-        persistentVolumeClaim:
-          defaultMode: {{ v.mount_mode | default(0755) }}
+        configMap:
+          defaultMode: {{ v.mount_mode | default("0755") }}
           name: {{ v.name }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Update the indentation of "with_items" to fix the " an undefined variable item" issue. Error details as follows:
`TASK [openshift-simple-service : Remove object definition] ********************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'item' is undefined\n\nThe error appears to have been in '/opt/operations/roles/openshift-simple-service/tasks/remove.yml': line 9, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Remove object definition\n  ^ here\n"}`